### PR TITLE
multer/refactor (10/24 11:07)

### DIFF
--- a/controllers/posts.js
+++ b/controllers/posts.js
@@ -28,10 +28,12 @@ class PostsController {
 
   createPost = async (req, res, next) => {
     try {
-      // const imgUrl = req.files.location; //잠시 주석처리
+      const imgUrl = req.files.location;
       const { userId, nickname } = res.locals.user;
       const { title, content } = req.body;
+      console.log(imgUrl, '99999');
 
+      // 이미지 데이터X 저장된 경로만 가져옴 // 잠시 주석처리
       if (!req.cookies[process.env.COOKIE_NAME]) {
         res.status(400);
         return;
@@ -41,6 +43,7 @@ class PostsController {
         nickname,
         title,
         content,
+        imgUrl,
       }); //imgUrl 잠시 지움
       res.status(200).json({ data: createPostData });
     } catch (error) {

--- a/middleware/upload-middleware.js
+++ b/middleware/upload-middleware.js
@@ -2,7 +2,6 @@ const multer = require('multer');
 const path = require('path');
 const AWS = require('aws-sdk');
 const multerS3 = require('multer-s3');
-console.log(AWS, '1234');
 require('dotenv').config();
 
 AWS.config.update({
@@ -15,8 +14,8 @@ const upload = multer({
   storage: multerS3({
     s3: new AWS.S3(),
     bucket: 'team4-mini',
-    async key(req, file, cb) {
-      await cb(null, `original/${Date.now()}_${path.basename(file.originalname)}`);
+    key(req, file, cb) {
+      cb(null, `original/${Date.now()}_${path.basename(file.originalname)}`);
       console.log(file.originalname);
     },
   }),

--- a/repositories/posts.js
+++ b/repositories/posts.js
@@ -22,13 +22,14 @@ class PostRepository {
     }
   };
 
-  createPost = async ({ userId, nickname, title, content }) => {
+  createPost = async ({ userId, nickname, title, content, imgUrl }) => {
     try {
       const createPostData = await Post.create({
         userId,
         nickname,
         title,
         content,
+        imgUrl,
         likeSum: 0,
       });
 

--- a/routes/posts.js
+++ b/routes/posts.js
@@ -9,7 +9,7 @@ const postsController = new PostsController();
 router.get('/', postsController.getPosts);
 router.get('/:postId', postsController.getPostById);
 //이미지를 업로드받고 저장경로를 client에 전달해줌 미들웨어의 정적파일을 제공하는 라우터
-router.post('/', authMiddleware, postsController.createPost); // upload.array('many') 잠시 주석
+router.post('/', upload.array('images'), authMiddleware, postsController.createPost); // upload.array('many') 잠시 주석
 router.put('/:postId', authMiddleware, postsController.updatePost);
 router.delete('/:postId', authMiddleware, postsController.deletePost);
 router.put('/likes/:postId', authMiddleware, postsController.likePost);

--- a/services/posts.js
+++ b/services/posts.js
@@ -27,13 +27,14 @@ class PostService {
     }
   };
 
-  createPost = async ({ userId, nickname, title, content }) => {
+  createPost = async ({ userId, nickname, title, content, imgUrl }) => {
     try {
       const createPostData = await this.postRepository.createPost({
         userId,
         nickname,
         title,
         content,
+        imgUrl,
       });
 
       return createPostData;


### PR DESCRIPTION
body의 제이슨 형식 content와 폼데이터로 보내진 파일을 동시에 받는 법을 아직 알지 못했습니다.
썬더클라이언트로는 불가능하다기에 프론트와 같이 해봐야할 것 같습니다.
썬더에서 formdata 파일부분만 filed name을 images로 지정해서 사진을 넣고 createPost의 req.body에서 가져온 content, title을 지우고 repository단에서 content, titled에 아무값이나 집어넣어주면 DB에 
"PostId": 6,
"userId": 2,
"nickname": "idid1",
"title": "테스트제목",
"content": "테스트게시글",
"imgUrl": ["https://team4-mini.s3.ap-northeast-2.amazonaws.com/original/1666621590987_DD810022-43E5-43D3-BAF6-90342F707CB0.jpeg"](https://team4-mini.s3.ap-northeast-2.amazonaws.com/original/1666621590987_DD810022-43E5-43D3-BAF6-90342F707CB0.jpeg),
"likesum": 0,
"createdAt": "2022-10-24T14:26:31.000Z",
"updatedAt": "2022-10-24T14:26:31.000Z" 일케 저장됩니다
